### PR TITLE
feature: v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.0.0] - 07/06/2022
+- feat: upgrade to support Dart `^2.17.0`
+- feat: additional lint rules:
+  - [sized_box_shrink_expand](https://dart-lang.github.io/linter/lints/sized_box_shrink_expand.html)
+  - [unnecessary_constructor_name](https://dart-lang.github.io/linter/lints/unnecessary_constructor_name.html)
+  - [unnecessary_late](https://dart-lang.github.io/linter/lints/unnecessary_late.html)
+  - [use_colored_box](https://dart-lang.github.io/linter/lints/use_colored_box.html)
+  - [use_decorated_box](https://dart-lang.github.io/linter/lints/use_decorated_box.html)
+  - [use_enums](https://dart-lang.github.io/linter/lints/use_enums.html)
+  - [use_super_parameters](https://dart-lang.github.io/linter/lints/use_super_parameters.html)
+
 ## [2.0.0+1] - 08/04/2021
 - Fix for pub.dev
 

--- a/README-TR.md
+++ b/README-TR.md
@@ -17,7 +17,7 @@ Kuralları kullanmak için aşağıdaki komutu `pubspec.yaml` dosyası içerisin
 
 ```yaml
 dev_dependencies:
-  flutrlint: ^2.0.0
+  flutrlint: ^3.0.0
 ```
 
 Projenizin ana dizinine `analysis_options.yaml` isimli bir dosya oluşturun ve içerisine aşağıdaki komutu ekleyin.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use these rules add the package below the `dev_dependencies` in the `pubspec.
 
 ```yaml
 dev_dependencies:
-  flutrlint: ^2.0.0
+  flutrlint: ^3.0.0
 ```
 
 Create a file named `analysis_options.yaml` on the root directory of the project and add the command below.

--- a/example/example.md
+++ b/example/example.md
@@ -4,7 +4,7 @@ To use these rules add the package below the `dev_dependencies` in the `pubspec.
 
 ```yaml
 dev_dependencies:
-  flutrlint: ^2.0.0
+  flutrlint: ^3.0.0
 ```
 
 Create a file named `analysis_options.yaml` on the root directory of the project and add the command below.

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -159,6 +159,7 @@ linter:
     # - public_member_api_docs
     - recursive_getters
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
@@ -174,9 +175,11 @@ linter:
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
+    - unnecessary_constructor_name
     # - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
+    - unnecessary_late
     - unnecessary_new
     - unnecessary_null_aware_assignments
     # Null Safety
@@ -195,6 +198,9 @@ linter:
     - unsafe_html
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
+    - use_colored_box
+    - use_decorated_box
+    - use_enums
     - use_is_even_rather_than_modulo
     # Null Safety
     - use_key_in_widget_constructors
@@ -202,6 +208,7 @@ linter:
     - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties
+    - use_super_parameters
     - use_string_buffers
     - use_to_and_as_if_applicable
     - valid_regexps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: flutrlint
 description: A custom analysis_options.yaml file created from Flutter Turkey for organization projects and anyone else.
-version: 2.0.0+1
+version: 3.0.0
 homepage: https://github.com/flutterturkey/flutrlint
 repository: https://github.com/flutterturkey/flutrlint
 issue_tracker: https://github.com/flutterturkey/flutrlint/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
- feat: upgrade to support Dart `^2.17.0`
- feat: additional lint rules:
  - [sized_box_shrink_expand](https://dart-lang.github.io/linter/lints/sized_box_shrink_expand.html)
  - [unnecessary_constructor_name](https://dart-lang.github.io/linter/lints/unnecessary_constructor_name.html)
  - [unnecessary_late](https://dart-lang.github.io/linter/lints/unnecessary_late.html)
  - [use_colored_box](https://dart-lang.github.io/linter/lints/use_colored_box.html)
  - [use_decorated_box](https://dart-lang.github.io/linter/lints/use_decorated_box.html)
  - [use_enums](https://dart-lang.github.io/linter/lints/use_enums.html)
  - [use_super_parameters](https://dart-lang.github.io/linter/lints/use_super_parameters.html)
